### PR TITLE
Restore Nieves unit test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+master_ut
+*.o

--- a/src/MasterUT/master_ut_init.cxx
+++ b/src/MasterUT/master_ut_init.cxx
@@ -8,21 +8,21 @@
 using namespace boost::unit_test;
 
 /* NOTE: no need to have input args - the way unit_test_main is called,
-         the args will get in (somehow) 
+         the args will get in (somehow)
 	 ... oh, that's actually not "somehow", that's likely to be done via
-	 framework::master_test_suite().argc and/or  framework::master_test_suite().argv[] 
+	 framework::master_test_suite().argc and/or  framework::master_test_suite().argv[]
 	 ... but if one passes then in explicitly, it'll probably work as well
 	 */
 bool init_unit_test_suite( /* int argc, char *argv[] */ )
 {
 
    auto ts1 = BOOST_TEST_SUITE("XSec");
-   
+
    ts1->add( BOOST_TEST_CASE( &lwlyn_ut ) );
-   // --> JVY, 4/29/19: remove for now as it give XSec=0 which is treated as error --> ts1->add( BOOST_TEST_CASE( &nieves_ut ) );
+   ts1->add( BOOST_TEST_CASE( &nieves_ut ) );
    ts1->add( BOOST_TEST_CASE( &singlekaon_ut ) ); // produces strangely large number
                                                                     // needs further understanding...
-      
+
    auto ts2 = BOOST_TEST_SUITE("ReWei");
    ts2->add( BOOST_TEST_CASE( &rw_XSecCCQE_ut ) );
    ts2->add( BOOST_TEST_CASE( &rw_XSecNCEL_ut ) );
@@ -31,10 +31,10 @@ bool init_unit_test_suite( /* int argc, char *argv[] */ )
    ts2->add( BOOST_TEST_CASE( &rw_XSecCOH_ut ) );
 
    // add other tests suites here...
-   
+
    framework::master_test_suite().add(ts1);
    framework::master_test_suite().add(ts2);
-     
+
    return true;
 
 }

--- a/src/XSecUT/nieves_ut.cxx
+++ b/src/XSecUT/nieves_ut.cxx
@@ -5,19 +5,20 @@ using namespace std;
 using namespace genie;
 using namespace boost::unit_test;
 
+#include "Physics/QuasiElastic/XSection/QELUtils.h"
 // nieves-specific
 #include "Physics/QuasiElastic/XSection/NievesQELCCPXSec.h"
 
 void nieves_ut()
 {
-      
+
    double tolerance_in_percent = 0.001;
 
    // this part below is identical between lwlyn and niev !!!
    //
    InitialState istate( 6, 12, 14 ); // tgt=Carbon, projectile=nu_mu
    istate.TgtPtr()->SetHitNucPdg( 2112 ); // "hit nucleon" is neutron
-   
+
    // kinematics
    //
    double Ev = 3; // in GeV
@@ -25,25 +26,39 @@ void nieves_ut()
    istate.SetProbeP4( nup4 );
    //
    ProcessInfo  procinfo( kScQuasiElastic, kIntWeakCC );
-   //        
+   //
    Interaction inter( istate, procinfo );
-   inter.KinePtr()->SetQ2( 2.0 ); // just to set something sensible...
-   
+
    NievesQELCCPXSec niev;
    // niev.Configure("Default");
    // niev.Configure("Dipole");
    niev.Configure( "ZExp" ); // as of trunk/v3, most recent valid configuration
 
+   RgKey nuclkey = "IntegralNuclearModel";
+   const NuclearModelI* nucl_model = dynamic_cast< const NuclearModelI* >(
+     niev.SubAlg(nuclkey) );
+   BOOST_CHECK( nucl_model );
+
+   // CM frame scattering angles of the outgoing lepton, measured with respect
+   // to the boost direction for going from the CM frame to the lab frame
+   double cos_theta_0 = 0.5;
+   double phi_0 = 0.;
+
+   double dummy_binding_energy = 0.;
+   double dummy_min_angle_EM = 0.;
+
+   QELEvGen_BindingMode_t hitNucleonBindingMode = kUseNuclearModel;
+
+   double xsec = utils::ComputeFullQELPXSec(&inter, nucl_model, &niev,
+     cos_theta_0, phi_0, dummy_binding_energy, hitNucleonBindingMode,
+     dummy_min_angle_EM, true);
+
    BOOST_CHECK( niev.ValidProcess( &inter ) );
 
-   KinePhaseSpace_t kpst = kPSQ2fE; 
-
-   double xsec = niev.XSec( &inter, kpst );
-   
    BOOST_REQUIRE_NE( xsec, 0. );
-   
-   // BOOST_CHECK_CLOSE( xsec, 1.335315e-11, tolerance_in_percent ); // going towards GENIE v3-series... but this was for "Dipole"
-   BOOST_CHECK_CLOSE( xsec, 1.195979e-11, tolerance_in_percent ); // this is for "ZExp", towards v3-series
-   
+
+   // this is for "ZExp", towards v3-series
+   BOOST_CHECK_CLOSE( xsec, 1.738095e-11, tolerance_in_percent );
+
    return;
 }


### PR DESCRIPTION
Due to the changes in the handling of quasielastic event generation in Generator R-3_00_04, the existing unit test for the Nieves CCQE model no longer works. This feature branch updates the test to be compatible with the latest generator code.